### PR TITLE
Fix NaN check

### DIFF
--- a/src/parsePropertiesFileToJson.ts
+++ b/src/parsePropertiesFileToJson.ts
@@ -20,7 +20,7 @@ const convertStringToActualType = (value: string): boolean | string | number | n
         return value === "true"
     }
     //if string can be converted to int 
-    if(parseInt(trimedValue) !== NaN) {
+    if(!isNaN(parseInt(trimedValue))) {
         return parseInt(trimedValue)
     }
     // if no match return value


### PR DESCRIPTION
NaN !== NaN cause... javascript shenanagans.  IsNaN is the correct way to check.